### PR TITLE
base de fiche generique roll20 pour fiche papier

### DIFF
--- a/base fiche roll20/fichebase.css
+++ b/base fiche roll20/fichebase.css
@@ -1,0 +1,23 @@
+﻿div.sheet-bgmain{
+	width: 800px;
+	max-width: 1280px;
+	height: 583px;
+	max-height: 583px;
+	text-align: center;
+	background-color : white;
+	background-image: url('http://i.imgur.com/QS0pFX8.jpg');
+	background-repeat: no-repeat;
+	background-position: left top;
+	background-size: auto;
+	position: relative;
+}
+div.sheet-abs{
+    position: absolute;
+    vertical-align: bottom;
+    display: inline-block;
+    /* border: 1px solid blue; */
+}
+div.sheet-rel{
+    position: relative;
+    display: inline-block;
+    /* border: 1px solid red; */

--- a/base fiche roll20/fichebase.html
+++ b/base fiche roll20/fichebase.html
@@ -1,0 +1,7 @@
+﻿<div class="sheet-bgmain">
+
+<div class="sheet-abs" style="left: 25px; top: 89px">
+<input name="attr_name" type="text" style="width: 127px" />
+</div>
+
+</div>


### PR DESCRIPTION
*html:
-en tête la place pour l'image de base: à paramétrer dans la feuille css
-ensuite un emplacement <div> + une zone texte à répliquer en modifiant le nom et la taille et le type
*css: 3 styles:
- 1 absolue pour l'image de fond :  
==>changez l'URL par votre image de fiche papier précédemment uploadée en ligne sur une service comme "imgur"
==> changez la taille de la zone pour coller à votre image
-1 pour les emplacements html <div> avec placement paramétrable